### PR TITLE
feat: Migrate from typescript-event-target to eventemitter3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,23 @@ import { Utils, RequestCommandId, ResponseCommandId, NiimbotBluetoothClient, Ima
 
 const client = new NiimbotBluetoothClient();
 
-client.addEventListener("packetsent", (e) => {
+client.on("packetsent", (e) => {
   console.log(`>> ${Utils.bufToHex(e.packet.toBytes())} (${RequestCommandId[e.packet.command]})`);
 });
 
-client.addEventListener("packetreceived", (e) => {
+client.on("packetreceived", (e) => {
   console.log(`<< ${Utils.bufToHex(e.packet.toBytes())} (${ResponseCommandId[e.packet.command]})`);
 });
 
-client.addEventListener("connect", () => {
+client.on("connect", () => {
   console.log("connected");
 });
 
-client.addEventListener("disconnect", () => {
+client.on("disconnect", () => {
   console.log("disconnected");
 });
 
-client.addEventListener("printprogress", (e) => {
+client.on("printprogress", (e) => {
   console.log(`Page ${e.page}/${e.pagesTotal}, Page print ${e.pagePrintProgress}%, Page feed ${e.pageFeedProgress}%`);
 });
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "async-mutex": "^0.5.0",
-    "typescript-event-target": "^1.1.1"
+    "eventemitter3": "^5.0.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,9 +1,16 @@
 import { ConnectionInfo, PrinterInfo } from ".";
-import { HeartbeatData } from "../packets/abstraction";
-import { NiimbotPacket } from "../packets/packet";
+import { HeartbeatData } from "./packets/abstraction";
+import { NiimbotPacket } from "./packets/packet";
 
+export class NiimbotEvent {
+  readonly type: string;
 
-export class ConnectEvent extends Event {
+  constructor(type: string) {
+    this.type = type;
+  }
+}
+
+export class ConnectEvent extends NiimbotEvent {
   info: ConnectionInfo;
   constructor(info: ConnectionInfo) {
     super("connect");
@@ -11,13 +18,13 @@ export class ConnectEvent extends Event {
   }
 }
 
-export class DisconnectEvent extends Event {
+export class DisconnectEvent extends NiimbotEvent {
   constructor() {
     super("disconnect");
   }
 }
 
-export class PacketReceivedEvent extends Event {
+export class PacketReceivedEvent extends NiimbotEvent {
   packet: NiimbotPacket;
   constructor(packet: NiimbotPacket) {
     super("packetreceived");
@@ -25,7 +32,7 @@ export class PacketReceivedEvent extends Event {
   }
 }
 
-export class PacketSentEvent extends Event {
+export class PacketSentEvent extends NiimbotEvent {
   packet: NiimbotPacket;
   constructor(packet: NiimbotPacket) {
     super("packetsent");
@@ -33,7 +40,7 @@ export class PacketSentEvent extends Event {
   }
 }
 
-export class RawPacketSentEvent extends Event {
+export class RawPacketSentEvent extends NiimbotEvent {
   data: Uint8Array;
   constructor(data: Uint8Array) {
     super("rawpacketsent");
@@ -41,7 +48,7 @@ export class RawPacketSentEvent extends Event {
   }
 }
 
-export class RawPacketReceivedEvent extends Event {
+export class RawPacketReceivedEvent extends NiimbotEvent {
   data: Uint8Array;
   constructor(data: Uint8Array) {
     super("rawpacketreceived");
@@ -49,7 +56,7 @@ export class RawPacketReceivedEvent extends Event {
   }
 }
 
-export class HeartbeatEvent extends Event {
+export class HeartbeatEvent extends NiimbotEvent {
   data: HeartbeatData;
   constructor(data: HeartbeatData) {
     super("heartbeat");
@@ -57,7 +64,7 @@ export class HeartbeatEvent extends Event {
   }
 }
 
-export class HeartbeatFailedEvent extends Event {
+export class HeartbeatFailedEvent extends NiimbotEvent {
   failedAttempts: number;
   constructor(failedAttempts: number) {
     super("heartbeatfailed");
@@ -65,7 +72,7 @@ export class HeartbeatFailedEvent extends Event {
   }
 }
 
-export class PrinterInfoFetchedEvent extends Event {
+export class PrinterInfoFetchedEvent extends NiimbotEvent {
   info: PrinterInfo;
   constructor(info: PrinterInfo) {
     super("printerinfofetched");
@@ -73,7 +80,7 @@ export class PrinterInfoFetchedEvent extends Event {
   }
 }
 
-export class PrintProgressEvent extends Event {
+export class PrintProgressEvent extends NiimbotEvent {
   /** 0 – n */
   page: number;
 
@@ -92,15 +99,15 @@ export class PrintProgressEvent extends Event {
   }
 }
 
-export interface ClientEventMap {
-  connect: ConnectEvent;
-  disconnect: DisconnectEvent;
-  rawpacketsent: RawPacketSentEvent;
-  rawpacketreceived: RawPacketReceivedEvent;
-  packetreceived: PacketReceivedEvent;
-  packetsent: PacketSentEvent;
-  heartbeat: HeartbeatEvent;
-  heartbeatfailed: HeartbeatFailedEvent;
-  printerinfofetched: PrinterInfoFetchedEvent;
-  printprogress: PrintProgressEvent;
+export type ClientEventMap = {
+  connect: (event: ConnectEvent) => void;
+  disconnect: (event: DisconnectEvent) => void;
+  rawpacketsent: (event: RawPacketSentEvent) => void;
+  rawpacketreceived: (event: RawPacketReceivedEvent) => void;
+  packetreceived: (event: PacketReceivedEvent) => void;
+  packetsent: (event: PacketSentEvent) => void;
+  heartbeat: (event: HeartbeatEvent) => void;
+  heartbeatfailed: (event: HeartbeatFailedEvent) => void;
+  printerinfofetched: (event: PrinterInfoFetchedEvent) => void;
+  printprogress: (event: PrintProgressEvent) => void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./packets";
+export * from "./events";
 export * from "./image_encoder";
 export * from "./utils";
 export * from "./printer_models";

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,15 +26,15 @@ async-mutex@^0.5.0:
   dependencies:
     tslib "^2.4.0"
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 tslib@^2.4.0:
   version "2.6.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
-
-typescript-event-target@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz"
-  integrity sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==
 
 typescript@^5.4.5:
   version "5.4.5"


### PR DESCRIPTION
This solved the cross-platform issue with EventTarget and Event for environments without browser implementation, like Hermes for React Native.

fix: https://github.com/MultiMote/niimbluelib/issues/4