### PR TITLE
Add B1_PRO to D110M_V4 print task mapping

### DIFF
--- a/src/print_tasks/index.ts
+++ b/src/print_tasks/index.ts
@@ -48,7 +48,7 @@ export const modelPrintTasks: Partial<Record<PrintTaskName, (ModelWithProtocol |
   B21_V1: [M.B21, M.B21_L2B],
   D110: [M.B21S, M.B21S_C2B, M.D110, { m: M.D11, v: 1 }, { m: M.D11, v: 2 }],
   B1: [M.D110_M, M.B1, M.B21_C2B, M.M2_H, M.N1, M.D101],
-  D110M_V4: [{ m: M.D110_M, v: 4 }, M.D11_H, M.B21_PRO],
+  D110M_V4: [{ m: M.D110_M, v: 4 }, M.D11_H, M.B21_PRO, M.B1_PRO],
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds `B1_PRO` to the `D110M_V4` print task mapping, fixing blank label / stuck progress when printing to a Niimbot B1 Pro.

## Context
The B1 Pro model metadata already exists in `printer_models.ts` but was missing from `modelPrintTasks`, causing `findPrintTask()` to return `undefined` and callers to fall back to the wrong print task (D110).

Confirmed working with `D110M_V4` by user testing (FW 2.09, HW 2.01) — see #1 (https://github.com/MultiMote/niimbluelib/issues/1#issuecomment-3865817003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Tested with my B1 Pro:
<img width="2000" height="1500" alt="image" src="https://github.com/user-attachments/assets/fb26ec9a-2c05-46d2-9e0d-b3328ff8ee8a" />

Without the fix it falls back to a different model and doesn't feed the right amount of lines and stops mid printing. In some cases I had it output just a white label without printing.

Thanks for this awesome library btw 🫶