### PR TITLE
fix: node BLE scan and connection setup

### DIFF
--- a/src/client/node_ble_impl.ts
+++ b/src/client/node_ble_impl.ts
@@ -56,21 +56,34 @@ export class NiimbotNodeBleClient extends NiimbotAbstractClient {
     return new Promise((resolve, reject) => {
       let timer: NodeJS.Timeout | undefined;
 
-      noble.on("discover", async (peripheral: Peripheral) => {
+      const cleanup = () => {
+        if (timer !== undefined) clearTimeout(timer);
+        noble.removeListener("discover", onDiscover);
+      };
+
+      const onDiscover = (peripheral: Peripheral) => {
         if (
-          peripheral.address === address.toLowerCase() ||
+          peripheral.address.toLowerCase() === address.toLowerCase() ||
           peripheral.advertisement.localName === address
         ) {
-          clearTimeout(timer);
-          resolve(peripheral);
+          cleanup();
+          void noble.stopScanningAsync()
+            .then(() => resolve(peripheral))
+            .catch(reject);
+        }
+      };
+
+      noble.on("discover", onDiscover);
+
+      noble.startScanning([], false, (error?: Error) => {
+        if (error) {
+          cleanup();
+          reject(error);
         }
       });
 
-      noble.startScanning([], false, (error?: Error) => {
-        if (error) reject(error);
-      });
-
       timer = setTimeout(() => {
+        cleanup();
         noble.stopScanning();
         reject(new Error("Device not found"));
       }, timeoutMs ?? 5000);


### PR DESCRIPTION
## Problem

On Linux/BlueZ, the Node BLE client started connecting immediately after discovering a printer while scanning was still active. On the Raspberry Pi, this could abort the connection or leave GATT service discovery incomplete.

As a result, the client failed with:

Unable to find suitable channel characteristic

or, in some cases:

Disconnected 62
le-connection-abort-by-local

The printer did expose the required characteristic, so the error was caused by the connection/discovery race rather than a missing characteristic. Direct MAC connections also failed when BlueZ returned the address with different casing.

Fix
- Stop and await BLE scanning before connecting.
- Normalize MAC address comparisons.
- Clean up discovery listeners and timers correctly.

Verified with a Niimbot D110 on a Raspberry Pi, including a five-image print job over a single BLE connection.
